### PR TITLE
Fix duplicate observer creation in HomeViewModel

### DIFF
--- a/feature-poker-planning/src/main/java/com/idk/feature_poker_planning/presentation/home/HomeViewModel.kt
+++ b/feature-poker-planning/src/main/java/com/idk/feature_poker_planning/presentation/home/HomeViewModel.kt
@@ -42,7 +42,6 @@ class HomeViewModel @Inject constructor(
     fun createRoom(desiredName: String? = null) {
         viewModelScope.launch {
             createRoomUseCase(desiredName)
-            observeRooms()
         }
     }
 


### PR DESCRIPTION
## Summary
- fix multiple room observation jobs starting when creating a room

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438d46a8448330aca11a7db8c9e1bd